### PR TITLE
Warn on stale market data

### DIFF
--- a/src/services/priceMonitoring.ts
+++ b/src/services/priceMonitoring.ts
@@ -17,7 +17,12 @@ export class PriceMonitor {
     
     const fetchPrice = async () => {
       try {
-        const data = await getMultiTimeframeData(symbol);
+        const result = await getMultiTimeframeData(symbol);
+        if (result.status.isStale) {
+          console.warn(`Data for ${symbol} is stale as of ${result.status.lastRefreshed}`);
+          return;
+        }
+        const data = result.data;
         if (data.day && data.day.length > 0) {
           const latestPrice = data.day[data.day.length - 1].close;
           callback({
@@ -54,7 +59,12 @@ export class PriceMonitor {
 
   async getCurrentPrice(symbol: string): Promise<number | null> {
     try {
-      const data = await getMultiTimeframeData(symbol);
+      const result = await getMultiTimeframeData(symbol);
+      if (result.status.isStale) {
+        console.warn(`Data for ${symbol} is stale as of ${result.status.lastRefreshed}`);
+        return null;
+      }
+      const data = result.data;
       if (data.day && data.day.length > 0) {
         return data.day[data.day.length - 1].close;
       }


### PR DESCRIPTION
## Summary
- parse and compare last refreshed timestamps from Alpha Vantage and Yahoo Finance responses
- flag stale quotes and return a structured status for downstream use
- skip price updates and option analysis when quotes are older than the latest trading session

## Testing
- `npm run lint` *(fails: actionTypes is assigned a value but only used as a type, Unexpected any)*
- `npm run build`
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_688e5d0f753083208577f85c8984a664