### PR TITLE
feat: explain option expiry

### DIFF
--- a/src/components/OptionsAnalysis.tsx
+++ b/src/components/OptionsAnalysis.tsx
@@ -25,6 +25,7 @@ interface OpenAIRecommendationResponse {
     targetPrice: number;
     priceType: 'bid' | 'ask';
     expirationDate: string;
+    expirationReason: string;
   };
   reasoning: string;
 }
@@ -140,14 +141,15 @@ IMPORTANT: Respond with ONLY valid JSON in this exact format (no markdown, no ex
     "optionType": "call" | "put",
     "targetPrice": number,
     "priceType": "bid" | "ask",
-    "expirationDate": "YYYY-MM-DD"
-  },
+      "expirationDate": "YYYY-MM-DD",
+      "expirationReason": "Why this expiration date was chosen"
+    },
   "reasoning": "Detailed explanation based on candlestick patterns"
 }
 
 If recommending "No Action Recommended", omit the "action" field entirely.
 
-Choose an expiration date that best supports the recommended option trade and provide it in YYYY-MM-DD format.
+Choose an expiration date that best supports the recommended option trade and provide it in YYYY-MM-DD format. Include a brief explanation of why this expiration date was chosen.
 
 Your recommendation should be grounded in technical analysis including RSI, 50- & 200-day moving averages (trend direction), MACD (momentum), On-Balance Volume (OBV for volume flow), Average True Range (ATR for volatility), broader volume analysis, momentum, and candlestick patterns. Look for confluence of multiple technical indicators. If there are clear technical signals from multiple indicators pointing in the same direction, provide a recommendation. If the technical indicators are mixed or neutral, set recommendationType to "No Action Recommended".
 
@@ -301,8 +303,9 @@ Technical Data: ${chartDescriptions}`
       formatted += `💡 Recommended Action:\n`;
       formatted += `Purchase (paper) ${response.action.optionType.toUpperCase()} Option at Strike Price of $${response.action.strikePrice}\n`;
       formatted += `Target ${response.action.priceType === 'bid' ? 'Bid' : 'Ask'} price: $${response.action.targetPrice}\n`;
-      formatted += `Expiration: ${response.action.expirationDate}\n\n`;
-    }
+        formatted += `Expiration: ${response.action.expirationDate}\n`;
+        formatted += `Expiration Rationale: ${response.action.expirationReason}\n\n`;
+      }
     
     formatted += `🔍 Candlestick Pattern Analysis:\n${response.reasoning}`;
     

--- a/src/components/TradeResults.tsx
+++ b/src/components/TradeResults.tsx
@@ -182,9 +182,15 @@ export function TradeResults({ onBack }: TradeResultsProps) {
                         </div>
                       </div>
                     </div>
-                    
+
+                    {trade.recommendation.action?.expirationReason && (
+                      <div className="mt-2 text-sm text-gray-600">
+                        Expiration Rationale: {trade.recommendation.action.expirationReason}
+                      </div>
+                    )}
+
                     <div className="mt-4 flex justify-end">
-                      <Button 
+                      <Button
                         onClick={() => handleCloseTrade(trade.id)}
                         variant="outline"
                         size="sm"

--- a/src/hooks/use-trade-tracking.ts
+++ b/src/hooks/use-trade-tracking.ts
@@ -5,15 +5,16 @@ export interface TrackedTrade {
   symbol: string;
   recommendation: {
     recommendationType: 'Call Option Recommended' | 'Put Option Recommended' | 'No Action Recommended';
-    action?: {
-      strikePrice: number;
-      optionType: 'call' | 'put';
-      targetPrice: number;
-      priceType: 'bid' | 'ask';
-      expirationDate: string;
+      action?: {
+        strikePrice: number;
+        optionType: 'call' | 'put';
+        targetPrice: number;
+        priceType: 'bid' | 'ask';
+        expirationDate: string;
+        expirationReason: string;
+      };
+      reasoning: string;
     };
-    reasoning: string;
-  };
   confirmedAt: Date;
   entryPrice?: number;
   currentPrice?: number;


### PR DESCRIPTION
## Summary
- capture `expirationReason` alongside option details in AI recommendations
- request and display rationale for chosen option expiration date
- surface expiration rationale on trade results view

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688e6f524188832088dd585397e04911