### PR TITLE
feat: add theme toggle and toasts

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,8 @@ import './App.css'
 import { StockInput } from '@/components/StockInput'
 import { OptionsAnalysis } from '@/components/OptionsAnalysis'
 import { TradeResults } from '@/components/TradeResults'
+import { ThemeToggle } from '@/components/ThemeToggle'
+import { Toaster } from '@/components/ui/toaster'
 
 type AppView = 'input' | 'analysis' | 'results';
 
@@ -28,32 +30,40 @@ function App() {
     setCurrentView('analysis');
   };
 
-  if (currentView === 'analysis' && selectedSymbols.length > 0) {
-    return <OptionsAnalysis symbols={selectedSymbols} onBack={handleBackToInput} />;
-  }
+  let content: JSX.Element;
 
-  if (currentView === 'results') {
-    return <TradeResults onBack={handleBackToAnalysis} />;
+  if (currentView === 'analysis' && selectedSymbols.length > 0) {
+    content = <OptionsAnalysis symbols={selectedSymbols} onBack={handleBackToInput} />;
+  } else if (currentView === 'results') {
+    content = <TradeResults onBack={handleBackToAnalysis} />;
+  } else {
+    content = (
+      <div className="min-h-screen bg-gray-100 p-4">
+        <div className="max-w-7xl mx-auto">
+          <div className="flex justify-between items-center mb-8">
+            <h1 className="text-3xl font-bold text-gray-800">
+              Stock Options Analysis
+            </h1>
+            <button
+              onClick={handleViewResults}
+              className="px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
+            >
+              View Trade Results
+            </button>
+          </div>
+
+          <StockInput onAnalyze={handleAnalyze} isLoading={false} />
+        </div>
+      </div>
+    );
   }
 
   return (
-    <div className="min-h-screen bg-gray-100 p-4">
-      <div className="max-w-7xl mx-auto">
-        <div className="flex justify-between items-center mb-8">
-          <h1 className="text-3xl font-bold text-gray-800">
-            Stock Options Analysis
-          </h1>
-          <button
-            onClick={handleViewResults}
-            className="px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
-          >
-            View Trade Results
-          </button>
-        </div>
-        
-        <StockInput onAnalyze={handleAnalyze} isLoading={false} />
-      </div>
-    </div>
+    <>
+      {content}
+      <ThemeToggle />
+      <Toaster />
+    </>
   )
 }
 

--- a/src/components/OptionsAnalysis.tsx
+++ b/src/components/OptionsAnalysis.tsx
@@ -4,6 +4,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Input } from '@/components/ui/input';
 import { Dialog, DialogContent } from '@/components/ui/dialog';
+import { toast } from '@/hooks/use-toast';
 import { getMultiTimeframeData, generateTechnicalAnalysis } from '@/services/alphaVantageApi';
 import { generateMultiTimeframeCharts, ChartImage } from '@/services/chartGenerator';
 import { useTradeTracking } from '@/hooks/use-trade-tracking';
@@ -457,6 +458,11 @@ ${technicalSummary}
     }
 
     setEntryPrices(prev => ({ ...prev, [rec.symbol]: '' }));
+
+    toast({
+      title: 'Trade tracking enabled',
+      description: `${rec.symbol} trade is now being tracked.`,
+    });
   };
 
   const handleEntryPriceChange = (symbol: string, value: string) => {

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -1,0 +1,40 @@
+import { useEffect, useState } from 'react';
+import { Sun, Moon } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+
+export function ThemeToggle() {
+  const getInitialTheme = (): 'light' | 'dark' => {
+    if (typeof window === 'undefined') return 'light';
+    const stored = localStorage.getItem('theme') as 'light' | 'dark' | null;
+    if (stored) return stored;
+    return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+  };
+
+  const [theme, setTheme] = useState<'light' | 'dark'>(getInitialTheme);
+
+  useEffect(() => {
+    const root = document.documentElement;
+    if (theme === 'dark') {
+      root.classList.add('dark');
+    } else {
+      root.classList.remove('dark');
+    }
+    localStorage.setItem('theme', theme);
+  }, [theme]);
+
+  const toggleTheme = () => {
+    setTheme(prev => (prev === 'dark' ? 'light' : 'dark'));
+  };
+
+  return (
+    <Button
+      variant="outline"
+      size="icon"
+      className="fixed top-4 right-4"
+      onClick={toggleTheme}
+      aria-label="Toggle theme"
+    >
+      {theme === 'dark' ? <Sun className="h-4 w-4" /> : <Moon className="h-4 w-4" />}
+    </Button>
+  );
+}

--- a/src/components/TradeResults.tsx
+++ b/src/components/TradeResults.tsx
@@ -4,6 +4,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { useTradeTracking, type TrackedTrade } from '@/hooks/use-trade-tracking';
 import { priceMonitor } from '@/services/priceMonitoring';
+import { toast } from '@/hooks/use-toast';
 
 interface TradeResultsProps {
   onBack: () => void;
@@ -47,6 +48,10 @@ export function TradeResults({ onBack }: TradeResultsProps) {
 
   const handleCloseTrade = (tradeId: string) => {
     closeTrade(tradeId);
+    toast({
+      title: 'Trade closed',
+      description: 'The trade has been marked as closed.',
+    });
   };
 
   const formatCurrency = (amount: number) => {


### PR DESCRIPTION
## Summary
- add reusable ThemeToggle component with persistent user preference
- show toast notifications when tracking or closing trades
- ensure toasts render across all views via shared Toaster

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688e78c714588320afb90d243c60f8a9